### PR TITLE
Provide an API appropriate for observing model updates in actors

### DIFF
--- a/Sources/Queried/MainModelContextObservingActor.swift
+++ b/Sources/Queried/MainModelContextObservingActor.swift
@@ -1,0 +1,54 @@
+//
+//  File.swift
+//  
+//
+//  Created by Juan Arzola on 7/27/24.
+//
+
+import Foundation
+import SwiftData
+
+/** 
+ An actor that can observe updates in the mainContext - on each update the actor should use its own new
+ `ModelContext` to re-fetch the descriptor if necessary.
+
+ # Example Usage
+```swift
+actor NotificationManager: MainModelContextUpdateObserver {
+    // Invoke this in a SwiftUI .task {} to start observing updates
+    public func updates(in modelContainer: ModelContainer) async {
+        let descriptor = FetchDescriptor<Item>(predicate: .true)
+        await forEachMainContextUpdate(of: modelContainer, relevantTo: descriptor) {
+            let modelContext = ModelContext(modelContainer)
+            do {
+                let items = try modelContext.fetch(descriptor)
+                // do something with items in the actor
+            } catch {
+                // handle the error
+            }
+        }
+    }
+}
+```
+ */
+public protocol MainModelContextObservingActor: Actor {
+
+    /// Awaits all of the container's mainContext updates relevant to a fetch descriptor, performing action when they occur.
+    func forEachMainContextUpdate<T: PersistentModel>(
+        of modelContainer: ModelContainer,
+        relevantTo descriptor: FetchDescriptor<T>,
+        perform action: () async -> Void
+    ) async;
+}
+
+public extension MainModelContextObservingActor {
+    func forEachMainContextUpdate<T: PersistentModel>(
+        of modelContainer: ModelContainer,
+        relevantTo descriptor: FetchDescriptor<T>,
+        perform action: () async -> Void
+    ) async {
+        for await _ in await modelContainer.mainContextUpdates(relevantTo: type(of: descriptor)) {
+            await action()
+        }
+    }
+}

--- a/Sources/Queried/ModelContainer+mainContextUpdates.swift
+++ b/Sources/Queried/ModelContainer+mainContextUpdates.swift
@@ -1,0 +1,51 @@
+//
+//  ModelContextAdditions.swift
+//
+//
+//  Created by Juan Arzola on 7/27/24.
+//
+
+import Foundation
+import SwiftData
+
+extension ModelContainer {
+    /**
+     * An AsyncStream that observes updates in the mainContext. This is meant to be used in actors
+     * @return An `AsyncStream` that emits an element each time there's an update in the main context for any `PersistentModel`s relevant to the  fetch descriptor that fetches `PersistentModel`s of type `T`.
+     */
+    @MainActor
+    public func mainContextUpdates<T: PersistentModel>(
+        relevantTo fetchDescriptorType: FetchDescriptor<T>.Type
+    ) -> AsyncStream<Void> {
+        return AsyncStream<Void> { continuation in
+            let mainContext = mainContext
+            Task {
+                let center = NotificationCenter.default
+                let notifications = center.notifications(
+                    named: Notification.Name("NSObjectsChangedInManagingContextNotification"),
+                    object: mainContext
+                ).filter { notification in
+                    guard let modelContext = notification.object as? ModelContext else {
+                        return false
+                    }
+                    let deleted = modelContext.deletedModelsArray
+                    let updated = modelContext.changedModelsArray
+                    let inserted = modelContext.insertedModelsArray
+                    let allUpdates = deleted + updated + inserted
+                    let names = ["\(T.self)"]
+                    let isRelevantUpdate = allUpdates.contains(where: { object in
+                        names.contains { object.persistentModelID.entityName == $0 }
+                    })
+                    return isRelevantUpdate
+                } .map { _ in }
+                Task {
+                    for await _ in notifications {
+                        continuation.yield()
+                    }
+                    continuation.finish()
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
The problem:
The Queried macro is not useful in actors because actors must own their own ModelContext, but since that model update is private it'll never have any external updates.

Solution:
Observe the main context for updates, then perform fetches in the private model context to perform any work related to said updates in the background.