### PR TITLE
Rename the generated function to {propertyName}AsyncStream instead of {propertyName} to avoid a conflict with @Observable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ class ContentController {
     // call this in a `.task()` in the view to keep ContentController up-to-date
     func updates(in container: ModelContainer) async {
         do {
-            for try await currItems in items(
+            for try await currItems in itemsAsyncStream(
                 FetchDescriptor(predicate: .true),
                 in: container.mainContext
             ) {

--- a/Sources/QueriedClient/main.swift
+++ b/Sources/QueriedClient/main.swift
@@ -9,7 +9,7 @@ class ContentViewModel {
 
     func updates(in container: ModelContainer) async {
         do {
-            for try await currItems in items(
+            for try await currItems in itemsAsyncStream(
                 FetchDescriptor(predicate: .true),
                 in: container.mainContext
             ) {

--- a/Sources/QueriedMacros/QueriedMacro.swift
+++ b/Sources/QueriedMacros/QueriedMacro.swift
@@ -41,7 +41,7 @@ public struct QueriedMacro: PeerMacro {
         let elementType = arrayTypeSyntax.element
         return [
             """
-            func \(name)<T: \(elementType)>(_ descriptor: FetchDescriptor<T>, in modelContext: ModelContext) -> AsyncThrowingStream<[T], Error> {
+            func \(name)AsyncStream<T: \(elementType)>(_ descriptor: FetchDescriptor<T>, in modelContext: ModelContext) -> AsyncThrowingStream<[T], Error> {
                 AsyncThrowingStream<[T], Error> { continuation in
                     let center = NotificationCenter.default
                     let notifications = center.notifications(named: Notification.Name("NSObjectsChangedInManagingContextNotification"), object: modelContext).filter { notification in

--- a/Tests/QueriedTests/QueriedTests.swift
+++ b/Tests/QueriedTests/QueriedTests.swift
@@ -31,7 +31,7 @@ final class QueriedTests: XCTestCase {
             class MyViewModel {
                 var items: [Item]
 
-                func items<T: Item>(_ descriptor: FetchDescriptor<T>, in modelContext: ModelContext) -> AsyncThrowingStream<[T], Error> {
+                func itemsAsyncStream<T: Item>(_ descriptor: FetchDescriptor<T>, in modelContext: ModelContext) -> AsyncThrowingStream<[T], Error> {
                     AsyncThrowingStream<[T], Error> { continuation in
                         let center = NotificationCenter.default
                         let notifications = center.notifications(named: Notification.Name("NSObjectsChangedInManagingContextNotification"), object: modelContext).filter { notification in
@@ -103,7 +103,7 @@ final class QueriedTests: XCTestCase {
             actor MyActor {
                 var items: [Item]
 
-                func items<T: Item>(_ descriptor: FetchDescriptor<T>, in modelContext: ModelContext) -> AsyncThrowingStream<[T], Error> {
+                func itemsAsyncStream<T: Item>(_ descriptor: FetchDescriptor<T>, in modelContext: ModelContext) -> AsyncThrowingStream<[T], Error> {
                     AsyncThrowingStream<[T], Error> { continuation in
                         let center = NotificationCenter.default
                         let notifications = center.notifications(named: Notification.Name("NSObjectsChangedInManagingContextNotification"), object: modelContext).filter { notification in


### PR DESCRIPTION
This allows using Queried and Observable to be used in the same property on Xcode 16