### PR TITLE
:bug: Do not access ModelContext from an unsupported thread

### DIFF
--- a/Sources/QueriedClient/main.swift
+++ b/Sources/QueriedClient/main.swift
@@ -9,11 +9,11 @@ class ContentViewModel {
 
     func updates(in container: ModelContainer) async {
         do {
-            for try await currItems in itemsAsyncStream(
+            for try await _ in itemsAsyncStream(
                 FetchDescriptor(predicate: .true),
                 in: container.mainContext
             ) {
-                print("\(#function): Got \(currItems.count) items.")
+                print("\(#function): Got \(items.count) items.")
             }
         } catch let error {
             print("\(#function): Error: \(error.localizedDescription)")

--- a/Sources/QueriedMacros/QueriedMacro.swift
+++ b/Sources/QueriedMacros/QueriedMacro.swift
@@ -42,46 +42,26 @@ public struct QueriedMacro: PeerMacro {
 
         return [
             """
-            func \(name)AsyncStream<T: \(elementType)>(_ descriptor: FetchDescriptor<T>, in modelContext: ModelContext) -> AsyncThrowingStream<[T], Error> {
-                AsyncThrowingStream<[T], Error> { continuation in
-                    let center = NotificationCenter.default
-                    let notificationName: Notification.Name
-                    if #available(iOS 18, *) {
-                        notificationName = ModelContext.willSave
-                    } else {
-                        notificationName = Notification.Name("NSObjectsChangedInManagingContextNotification")
-                    }
-                    let notifications = center.notifications(named: notificationName, object: modelContext).filter { notification in
-                        guard let modelContext = notification.object as? ModelContext else { return false }
-                        let deleted = modelContext.deletedModelsArray
-                        let updated = modelContext.changedModelsArray
-                        let inserted = modelContext.insertedModelsArray
-                        let allUpdates = deleted + updated + inserted
-                        let names = ["\\(T.self)"]
-                        let isRelevantUpdate = allUpdates.contains(where: { object in
-                            names.contains { object.persistentModelID.entityName == $0 }
-                        })
-                        return isRelevantUpdate
-                    }.map { _ in }
-
+            func \(name)AsyncStream<T: \(elementType)>(_ descriptor: FetchDescriptor<T>, in modelContext: ModelContext) -> AsyncThrowingStream<Void, Error> {
+                AsyncThrowingStream<Void, Error> { continuation in
                     func refetch() throws -> [T] {
                         try modelContext.fetch(descriptor)
                     }
                     do {
                         let firstItems = try refetch()
                         self.\(name) = firstItems
-                        continuation.yield(firstItems)
+                        continuation.yield()
                     } catch let error {
                         self.\(name) = []
                         continuation.finish(throwing: error)
                         return
                     }
-                    Task {
+                    let task = Task {
                         do {
-                            for await _ in notifications {
+                            for await _ in modelContext.updates(relevantTo: type(of: descriptor)) {
                                 let items = try refetch()
                                 self.\(name) = items
-                                continuation.yield(items)
+                                continuation.yield()
                             }
                             continuation.finish()
                         } catch let error {
@@ -89,9 +69,11 @@ public struct QueriedMacro: PeerMacro {
                             continuation.finish(throwing: error)
                         }
                     }
+                    continuation.onTermination = { _ in
+                        task.cancel()
+                    }
                 }
             }
-
             """
         ]
     }


### PR DESCRIPTION
- ModelContext needs to be accessed in the thread of the notification. Using filter seems to change the thread, which causes race/condition crashes I've experienced.
 - Fix this by handling the notification using Combine and filtering in its handler, which uses the same thread as the notification is posted on.
 - Also Queried's async stream now returns void because the values aren't sendable, so they can't be sent to continuation.yield(). This was risky anyways because we can't guarantee that this value was going to be used downstream in the same thread of the modelContext. We can access the value safely from the property modified by the macro.